### PR TITLE
feat: reduce LaTeX dependency to minimal required packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,7 @@ jobs:
           texlive-latex-base \
           texlive-latex-recommended \
           texlive-latex-extra \
-          texlive-pictures \
-          texlive-fonts-recommended
+          texlive-pictures
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,11 @@ jobs:
     - name: Install LaTeX
       run: |
         sudo apt-get update
-        sudo apt-get install -y texlive-full
+        sudo apt-get install -y --no-install-recommends \
+          texlive-latex-base \
+          texlive-latex-extra \
+          texlive-pictures \
+          texlive-fonts-recommended
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           texlive-latex-base \
+          texlive-latex-recommended \
           texlive-latex-extra \
           texlive-pictures \
           texlive-fonts-recommended

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ pip install -e .
 Note: PDF and PNG generation require `pdflatex` to be installed and available in PATH. Tested methods have a ✅ next to them. Methods include:
 
 - macOS:
-    - Install [MacTEX](https://www.tug.org/mactex/mactex-download.html) ✅
-    - `brew install --cask mactex`
+    - `brew install --cask basictex` ✅ (lightweight, ~100 MB)
+    - `brew install --cask mactex` (full install, ~5 GB)
 - Ubuntu:
-    - `sudo apt-get install texlive-full` ✅
-- Windows: Install [MiKTeX](https://miktex.org/download)
+    - `sudo apt-get install -y --no-install-recommends texlive-latex-base texlive-latex-extra texlive-pictures texlive-fonts-recommended` ✅
+- Windows: Install [MiKTeX](https://miktex.org/download) (auto-downloads required packages on first run)
 
 ### PNG generation
 

--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -1703,7 +1703,6 @@ def latex_wrapper(tikz_code: str) -> str:
         Complete LaTeX document as a string.
     """
     latex_document = f"""\\documentclass[tikz,border=10pt]{{standalone}}
-                        \\usepackage{{lmodern}}
                         \\linespread{{1.10}}
                         \\usetikzlibrary{{shapes}}
                         \\usetikzlibrary{{arrows.meta}}

--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -1703,7 +1703,7 @@ def latex_wrapper(tikz_code: str) -> str:
         Complete LaTeX document as a string.
     """
     latex_document = f"""\\documentclass[tikz,border=10pt]{{standalone}}
-                        \\usepackage{{newpxtext,newpxmath}}
+                        \\usepackage{{lmodern}}
                         \\linespread{{1.10}}
                         \\usetikzlibrary{{shapes}}
                         \\usetikzlibrary{{arrows.meta}}


### PR DESCRIPTION
Replace texlive-full (~1.5 GB) with a minimal set of packages that provides exactly what draw_tree needs:

  texlive-latex-base    - pdflatex engine and core LaTeX
  texlive-latex-extra   - standalone document class
  texlive-pictures      - PGF/TikZ with shapes and arrows.meta libraries
  texlive-fonts-recommended - Latin Modern fonts (lmodern)

Also switch the font in latex_wrapper() from newpxtext/newpxmath (which requires texlive-fonts-extra, ~650 MB) to lmodern, which is available in the much smaller texlive-fonts-recommended package.

Update README.md to reflect the minimal install commands for Ubuntu and add brew install --cask basictex as a lightweight macOS option.

Closes #41

Note: Submitting this as part of my GSoC 2026 application for Project 2 (GameInterpreter), as suggested in the outreach email.