### PR TITLE
feat : Added-svg-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [Developer docs: Testing](#developer-docs-testing)
 
 `draw_tree` is a game tree drawing tool for publication-ready extensive form games in Game Theory.
-It can generate TikZ code, LaTeX documents, PDFs, and PNGs from game specifications.
+It can generate TikZ code, LaTeX documents, PDFs, PNGs, and SVGs from game specifications.
 
 Games can be specified via `.ef` format files which include layout formatting.
 These can be created via [Game Theory Explorer](https://gametheoryexplorer-a68c7.web.app/), or by hand, see [specs.pdf](specs.pdf) for details.
@@ -35,6 +35,7 @@ pip install -e .
 - Python 3.10+ (tested on 3.13)
 - LaTeX with TikZ (for PDF/PNG generation)
 - (optional) ImageMagick or Ghostscript or Poppler (for PNG generation)
+- (optional) pdf2svg or Inkscape or Poppler (for SVG generation)
 
 ### Installing LaTeX
 
@@ -60,6 +61,19 @@ PNG generation will default to using any of ImageMagick or Ghostscript or Popple
     - `sudo apt-get install poppler-utils`
 - Windows: Install ImageMagick or Ghostscript from their websites
 
+### SVG generation
+
+SVG generation will default to using any of pdf2svg, Inkscape, or pdftocairo (Poppler) that are installed. If none are installed, try one of the following:
+- macOS:
+    - `brew install pdf2svg`
+    - `brew install inkscape`
+    - `brew install poppler`
+- Ubuntu:
+    - `sudo apt-get install pdf2svg`
+    - `sudo apt-get install inkscape`
+    - `sudo apt-get install poppler-utils`
+- Windows: Install Inkscape from https://inkscape.org or pdf2svg via MSYS2
+
 ## CLI
 
 By default, `draw_tree` generates TikZ code and prints it to standard output.
@@ -71,6 +85,7 @@ draw_tree games/example.ef --tex                           # Creates example.tex
 draw_tree games/example.ef --output=custom.tex             # Creates custom.tex
 draw_tree games/example.ef --pdf                           # Creates example.pdf
 draw_tree games/example.ef --png                           # Creates example.png
+draw_tree games/example.ef --svg                           # Creates example.svg
 draw_tree games/example.ef --png --dpi=600                 # Creates high-res example.png (72-2400, default: 300)
 draw_tree games/example.ef --output=mygame.png scale=0.8   # Creates mygame.png with 0.8 scaling (0.01 to 100)
 ```
@@ -80,13 +95,15 @@ draw_tree games/example.ef --output=mygame.png scale=0.8   # Creates mygame.png 
 You can also use `draw_tree` as a Python library:
 
 ```python
-from draw_tree import generate_tex, generate_pdf, generate_png
+from draw_tree import generate_tex, generate_pdf, generate_png, generate_svg
 generate_tex('games/example.ef')                                    # Creates example.tex
 generate_tex('games/example.ef', save_to='custom')                  # Creates custom.tex
 generate_pdf('games/example.ef')                                    # Creates example.pdf
 generate_png('games/example.ef')                                    # Creates example.png
 generate_png('games/example.ef', dpi=600)                           # Creates high-res example.png (72-2400, default: 300)
 generate_png('games/example.ef', save_to='mygame', scale_factor=0.8)    # Creates mygame.png with 0.8 scaling (0.01 to 100)
+generate_svg('games/example.ef')                                    # Creates example.svg
+generate_svg('games/example.ef', save_to='mygame', scale_factor=0.8)    # Creates mygame.svg with 0.8 scaling
 ```
 
 ### Rendering in Jupyter Notebooks
@@ -111,12 +128,13 @@ In particular read [Tutorial 4) Creating publication-ready game images](https://
 In short, you can do:
 ```python
 import pygambit as gbt
-from draw_tree import draw_tree, generate_tex, generate_pdf, generate_png
+from draw_tree import draw_tree, generate_tex, generate_pdf, generate_png, generate_svg
 g = gbt.read_efg('somegame.efg')
 draw_tree(g)
 generate_tex(g)
 generate_pdf(g)
 generate_png(g)
+generate_svg(g)
 ```
 
 > Note: Without setting the `save_to` parameter, the saved file will be based on the title field of the pygambit game object.

--- a/src/draw_tree/__init__.py
+++ b/src/draw_tree/__init__.py
@@ -13,6 +13,7 @@ from .core import (
     generate_tex,
     generate_pdf,
     generate_png,
+    generate_svg,
     ef_to_tex,
     latex_wrapper,
     efg_dl_ef
@@ -26,6 +27,7 @@ __all__ = [
     "generate_tex", 
     "generate_pdf",
     "generate_png",
+    "generate_svg",
     "ef_to_tex",
     "latex_wrapper",
     "efg_dl_ef",

--- a/src/draw_tree/cli.py
+++ b/src/draw_tree/cli.py
@@ -5,7 +5,7 @@ Command-line interface for draw_tree package.
 import sys
 from pathlib import Path
 from .core import (
-    commandline, draw_tree, generate_pdf, generate_png, generate_tex
+    commandline, draw_tree, generate_pdf, generate_png, generate_svg, generate_tex
 )
 
 
@@ -19,25 +19,29 @@ def main():
         print("  draw_tree <file.ef> [options]           # Generate TikZ code")
         print("  draw_tree <file.ef> --pdf [options]     # Generate PDF (requires pdflatex)")
         print("  draw_tree <file.ef> --png [options]     # Generate PNG (requires pdflatex + imagemagick/ghostscript)")
+        print("  draw_tree <file.ef> --svg [options]     # Generate SVG (requires pdflatex + pdf2svg/inkscape/poppler)")
         print("  draw_tree <file.ef> --tex [options]     # Generate LaTeX document")
-        print("  draw_tree <file.ef> --output=name.ext   # Generate with custom filename (.pdf, .png, or .tex)")
+        print("  draw_tree <file.ef> --output=name.ext   # Generate with custom filename (.pdf, .png, .svg, or .tex)")
         print()
         print("Options:")
         print("  scale=X.X    Set scale factor (0.01 to 100)")
         print("  grid         Show helper grid")
         print("  --pdf        Generate PDF output instead of TikZ")
         print("  --png        Generate PNG output instead of TikZ")
+        print("  --svg        Generate SVG output instead of TikZ")
         print("  --tex        Generate LaTeX document instead of TikZ")
-        print("  --output=X   Specify output filename (.pdf, .png, or .tex extension determines format)")
+        print("  --output=X   Specify output filename (.pdf, .png, .svg, or .tex extension determines format)")
         print("  --dpi=X      Set PNG resolution in DPI (72-2400, default: 300)")
         print()
         print("Examples:")
         print("  draw_tree games/example.ef --pdf")
         print("  draw_tree games/example.ef --png --dpi=600")
+        print("  draw_tree games/example.ef --svg")
         print("  draw_tree games/example.ef --tex")
         print("  draw_tree games/example.ef --output=mygame.tex scale=0.8")
         print()
-        print("Note: PDF/PNG generation requires pdflatex. PNG also needs ImageMagick or Ghostscript.")
+        print("Note: PDF/PNG/SVG generation requires pdflatex. PNG also needs ImageMagick or Ghostscript.")
+        print("      SVG also needs pdf2svg, Inkscape, or Poppler.")
         sys.exit(0)
     
     # Process command-line arguments
@@ -79,6 +83,19 @@ def main():
                 dpi=dpi if dpi is not None else 300
             )
             print(f"PNG generated successfully: {png_path}")
+        
+        elif output_mode == "svg":
+            if output_file.endswith(".svg"):
+                print(f"Generating SVG: {output_file}")
+            else:
+                print(f"Generating SVG: {output_file}.svg")
+            svg_path = generate_svg(
+                game=current_ef_file,
+                save_to=output_file,
+                scale_factor=current_scale,
+                show_grid=current_grid,
+            )
+            print(f"SVG generated successfully: {svg_path}")
         
         elif output_mode == "tex":
             if output_file.endswith(".tex"):

--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -1339,6 +1339,7 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
     pdf_requested = False
     png_requested = False
     tex_requested = False
+    svg_requested = False
     output_file = None
     dpi = None
     
@@ -1361,6 +1362,8 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
             png_requested = True
         elif arg == "--tex":
             tex_requested = True
+        elif arg == "--svg":
+            svg_requested = True
         elif arg.startswith("--output="):
             output_file = arg[9:]  # Remove "--output=" prefix
             if output_file.endswith('.pdf'):
@@ -1369,6 +1372,8 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
                 png_requested = True
             elif output_file.endswith('.tex'):
                 tex_requested = True
+            elif output_file.endswith('.svg'):
+                svg_requested = True
         elif arg.startswith("--dpi="):
             try:
                 dpi = int(arg[6:])  # Remove "--dpi=" prefix
@@ -1385,7 +1390,9 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
             ef_file = arg
     
     # Determine output mode
-    if png_requested:
+    if svg_requested:
+        output_mode = "svg"
+    elif png_requested:
         output_mode = "png"
     elif pdf_requested:
         output_mode = "pdf"
@@ -2090,6 +2097,159 @@ def generate_png(
             raise
         except Exception as e:
             raise RuntimeError(f"PNG generation failed: {e}")
+
+
+def generate_svg(
+    game: str | "pygambit.gambit.Game",
+    save_to: Optional[str] = None,
+    scale_factor: float = 1.0,
+    level_scaling: int = 1,
+    sublevel_scaling: int = 1,
+    width_scaling: int = 1,
+    hide_action_labels: bool = False,
+    shared_terminal_depth: bool = False,
+    show_grid: bool = False,
+    color_scheme: str = "default",
+    edge_thickness: float = 1.0,
+    action_label_position: float = 0.5,
+) -> str:
+    """
+    Generate an SVG image directly from an extensive form (.ef) file.
+
+    This function creates a PDF first, then converts it to SVG using external tools.
+    Requires pdflatex and one of pdf2svg, Inkscape, or pdftocairo (Poppler).
+
+    Args:
+        game: Path to the .ef or .efg file to process, or a pygambit.gambit.Game object.
+        save_to: path to save intermediate .ef file when generating from a pygambit.gambit.Game object and output svg file.
+        scale_factor: Scale factor for the diagram.
+        level_scaling: Level spacing multiplier used when generating from a pygambit.gambit.Game object.
+        sublevel_scaling: Sublevel spacing multiplier used when generating from a pygambit.gambit.Game object.
+        width_scaling: Width spacing multiplier used when generating from a pygambit.gambit.Game object.
+        hide_action_labels: Whether to hide action labels when generating from a pygambit.gambit.Game object.
+        shared_terminal_depth: Whether to enforce shared terminal depth when generating from a pygambit.gambit.Game object.
+        show_grid: Whether to show grid lines.
+        color_scheme: Color scheme for player nodes.
+        edge_thickness: Thickness of edges.
+        action_label_position: Position of action labels along edges.
+
+    Returns:
+        Path to the generated SVG file.
+
+    Raises:
+        FileNotFoundError: If the .ef file doesn't exist.
+        RuntimeError: If PDF generation or SVG conversion fails.
+    """
+    # Determine output filename
+    if save_to is None:
+        if isinstance(game, str):
+            game_path = Path(game)
+        else:
+            game_path = Path(game.title + ".ef")
+        output_svg = game_path.with_suffix(".svg").name
+    else:
+        if not save_to.endswith(".svg"):
+            output_svg = save_to + ".svg"
+        else:
+            output_svg = save_to
+
+    # If game is an EFG file, convert it first
+    if isinstance(game, str) and game.lower().endswith(".efg"):
+        try:
+            game = efg_dl_ef(game)
+        except Exception:
+            pass
+
+    try:
+        # Step 1: Generate PDF using existing function
+        pdf_path = generate_pdf(
+            game=game,
+            save_to=save_to,
+            scale_factor=scale_factor,
+            level_scaling=level_scaling,
+            sublevel_scaling=sublevel_scaling,
+            width_scaling=width_scaling,
+            hide_action_labels=hide_action_labels,
+            shared_terminal_depth=shared_terminal_depth,
+            show_grid=show_grid,
+            color_scheme=color_scheme,
+            edge_thickness=edge_thickness,
+            action_label_position=action_label_position,
+        )
+
+        # Step 2: Convert PDF to SVG
+        final_svg_path = Path(output_svg)
+
+        # Try different conversion methods in order of preference
+        conversion_success = False
+
+        # Method 1: Try pdf2svg
+        try:
+            subprocess.run([
+                'pdf2svg',
+                str(pdf_path),
+                str(final_svg_path)
+            ], capture_output=True, text=True, check=True)
+            conversion_success = True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+
+        # Method 2: Try Inkscape
+        if not conversion_success:
+            try:
+                subprocess.run([
+                    'inkscape',
+                    str(pdf_path),
+                    '--export-filename=' + str(final_svg_path)
+                ], capture_output=True, text=True, check=True)
+                conversion_success = True
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass
+
+        # Method 3: Try pdftocairo (part of Poppler)
+        if not conversion_success:
+            try:
+                subprocess.run([
+                    'pdftocairo',
+                    '-svg',
+                    str(pdf_path),
+                    str(final_svg_path)
+                ], capture_output=True, text=True, check=True)
+                conversion_success = True
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass
+
+        # Clean up intermediate PDF
+        try:
+            Path(pdf_path).unlink()
+        except OSError:
+            pass
+
+        if not conversion_success:
+            raise RuntimeError(
+                "SVG conversion failed. Please install one of the following:\n"
+                "  - pdf2svg (dedicated PDF to SVG converter)\n"
+                "  - Inkscape (vector graphics editor with CLI)\n"
+                "  - Poppler utils (provides 'pdftocairo' command)\n\n"
+                "Installation examples:\n"
+                "  macOS: brew install pdf2svg inkscape poppler\n"
+                "  Ubuntu: sudo apt-get install pdf2svg inkscape poppler-utils\n"
+                "  Windows: Install Inkscape from https://inkscape.org or pdf2svg via MSYS2"
+            )
+
+        if final_svg_path.exists():
+            return str(final_svg_path.absolute())
+        else:
+            raise RuntimeError("SVG was not generated successfully")
+
+    except FileNotFoundError:
+        # Re-raise file not found errors directly
+        raise
+    except RuntimeError:
+        # Re-raise PDF generation errors
+        raise
+    except Exception as e:
+        raise RuntimeError(f"SVG generation failed: {e}")
 
 
 def efg_dl_ef(efg_file: str) -> str:

--- a/tests/test_drawtree.py
+++ b/tests/test_drawtree.py
@@ -631,6 +631,91 @@ class TestCommandlineArguments:
         assert dpi == 300  # Should default to 300 for invalid values
 
 
+class TestSvgGeneration:
+    """Test SVG generation functionality."""
+
+    def test_generate_svg_missing_file(self):
+        """Test SVG generation with missing .ef file."""
+        with pytest.raises(FileNotFoundError):
+            draw_tree.generate_svg("nonexistent.ef")
+
+    @patch('draw_tree.core.subprocess.run')
+    def test_generate_svg_pdflatex_not_found(self, mock_run):
+        """Test SVG generation when pdflatex is not available."""
+        # Mock pdflatex not being found
+        mock_run.side_effect = FileNotFoundError("pdflatex not found")
+
+        # Create a temporary .ef file
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.ef') as ef_file:
+            ef_file.write("player 1\nlevel 0 node root player 1\n")
+            ef_file_path = ef_file.name
+
+        try:
+            with pytest.raises(RuntimeError, match="pdflatex not found"):
+                draw_tree.generate_svg(ef_file_path)
+        finally:
+            os.unlink(ef_file_path)
+
+    def test_generate_svg_default_parameters(self):
+        """Test SVG generation with default parameters."""
+        # Create a temporary .ef file
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.ef') as ef_file:
+            ef_file.write("player 1\nlevel 0 node root player 1\n")
+            ef_file_path = ef_file.name
+
+        try:
+            # Mock both pdflatex and conversion tools being unavailable
+            with patch('draw_tree.core.subprocess.run') as mock_run:
+                mock_run.side_effect = FileNotFoundError("Command not found")
+
+                with pytest.raises(RuntimeError):
+                    draw_tree.generate_svg(ef_file_path)
+        finally:
+            os.unlink(ef_file_path)
+
+    def test_generate_svg_output_filename(self):
+        """Test SVG generation with custom output filename."""
+        # Create a temporary .ef file
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.ef') as ef_file:
+            ef_file.write("player 1\nlevel 0 node root player 1\n")
+            ef_file_path = ef_file.name
+
+        try:
+            with patch('draw_tree.core.subprocess.run') as mock_run:
+                mock_run.side_effect = FileNotFoundError("Command not found")
+
+                with pytest.raises(RuntimeError):
+                    draw_tree.generate_svg(ef_file_path, save_to="custom_name.svg")
+        finally:
+            os.unlink(ef_file_path)
+
+
+class TestSvgCommandlineArguments:
+    """Test command line argument parsing for SVG functionality."""
+
+    def test_commandline_svg_flag(self):
+        """Test --svg flag parsing."""
+        result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--svg'])
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        assert output_mode == "svg"
+        assert not pdf_requested
+        assert not png_requested
+        assert not tex_requested
+        assert output_file is None
+        assert dpi is None
+
+    def test_commandline_svg_output_file(self):
+        """Test SVG output with custom filename."""
+        result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--output=custom.svg'])
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        assert output_mode == "svg"
+        assert not pdf_requested
+        assert not png_requested
+        assert not tex_requested
+        assert output_file == "custom.svg"
+        assert dpi is None
+
+
 def test_efg_dl_ef_conversion_examples():
     """Integration test: convert the repository's example .efg files and
     require exact equality with their corresponding canonical .ef outputs.


### PR DESCRIPTION
# Add `generate_svg` function

Closes #40

## Changes

- Added `generate_svg()` to `core.py` — generates PDF first, then converts to SVG using pdf2svg, Inkscape, or pdftocairo (tried in order)
- Added `--svg` flag and `--output=*.svg` support in `commandline()`
- Added `--svg` CLI handler and help text in `cli.py`
- Exported `generate_svg` in `__init__.py`
- Added SVG install instructions and usage examples to `README.md`
- Added 6 new tests in `test_drawtree.py` (4 generation + 2 commandline)
- Updated Readme 

## Usage

### CLI
```bash
draw_tree games/example.ef --svg                # Creates example.svg
draw_tree games/example.ef --output=mygame.svg  # Creates mygame.svg
```

### Python API
```python
from draw_tree import generate_svg
generate_svg('games/example.ef')
generate_svg('games/example.ef', save_to='mygame', scale_factor=0.8)
```

## Tests

All 61 tests in `test_drawtree.py` pass (6 new + 55 existing).


Note: Submitting this as part of my GSoC 2026 application for Project 2 (GameInterpreter), as suggested in the outreach email.