### PR TITLE
Reduce LaTeX dependency from texlive-full to minimal required packages (closes #41)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install LaTeX
       run: |
         sudo apt-get update
-        sudo apt-get install -y texlive-full
+        sudo apt-get install -y texlive-base texlive-latex-extra texlive-fonts-extra texlive-pictures
         
     - name: Install dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Note: PDF and PNG generation require `pdflatex` to be installed and available in
     - Install [MacTEX](https://www.tug.org/mactex/mactex-download.html) ✅
     - `brew install --cask mactex`
 - Ubuntu:
-    - `sudo apt-get install texlive-full` ✅
+    - `sudo apt-get install texlive-base texlive-latex-extra texlive-fonts-extra texlive-pictures` ✅
 - Windows: Install [MiKTeX](https://miktex.org/download)
 
 ### PNG generation


### PR DESCRIPTION
This PR is submitted as part of my GSoC 2026 application for the Gambit project (Idea 2: GameInterpreter).
Closes https://github.com/gambitproject/draw_tree/issues/41.

**Problem:** texlive-full is ~1.5GB and much larger than necessary for draw_tree's actual requirements.

**Investigation:** The generated .tex files only use:
- standalone documentclass
- newpxtext, newpxmath fonts
- TikZ with shapes and arrows.meta libraries

**Fix:** Replaced texlive-full with the minimal set of packages that provide exactly these:
- texlive-base - provides pdflatex
- texlive-latex-extra - provides standalone documentclass
- texlive-fonts-extra - provides newpxtext, newpxmath fonts
- texlive-pictures - provides TikZ, shapes, arrows.meta

**Changes:**
- Updated README.md Ubuntu install instructions
- Updated .github/workflows/test.yml CI to use minimal packages

**Testing:** Verified generate_pdf works successfully with the minimal package set in Docker by building a test image with only these four packages and confirming PDF generation completes without errors.

**Downstream impact:** The game repo (GameInterpreter app) also uses texlive-full in its Dockerfile.backend. The same minimal package set should apply there too, which would significantly reduce its Docker build time. A separate PR to the game repo can follow once this is merged.