### PR TITLE
Extend player-based colour schemes (Fixes #14) and fix PNG generation issue (Fixes #37) 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = ["jupyter-tikz", "ipykernel"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0.0", "pytest-cov", "nbformat", "nbclient", "ipykernel", "pygambit"]
+colors = ["distinctipy"]
 
 [project.scripts]
 draw_tree = "draw_tree.cli:main"

--- a/src/draw_tree/cli.py
+++ b/src/draw_tree/cli.py
@@ -30,6 +30,7 @@ def main():
         print("  --tex        Generate LaTeX document instead of TikZ")
         print("  --output=X   Specify output filename (.pdf, .png, or .tex extension determines format)")
         print("  --dpi=X      Set PNG resolution in DPI (72-2400, default: 300)")
+        print("  --color-scheme=X  Three color schemes: default (no colors), gambit (≤6 players), distinctipy (n from game)")
         print()
         print("Examples:")
         print("  draw_tree games/example.ef --pdf")
@@ -41,7 +42,7 @@ def main():
         sys.exit(0)
     
     # Process command-line arguments
-    output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = commandline(sys.argv)
+    output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = commandline(sys.argv)
     
     # Import the core module to access global variables after commandline() has set them
     from . import core
@@ -62,7 +63,8 @@ def main():
                 game=current_ef_file,
                 save_to=output_file,
                 scale_factor=current_scale,
-                show_grid=current_grid
+                show_grid=current_grid,
+                color_scheme=color_scheme,
             )
             print(f"PDF generated successfully: {pdf_path}")
         
@@ -76,7 +78,8 @@ def main():
                 save_to=output_file,
                 scale_factor=current_scale,
                 show_grid=current_grid,
-                dpi=dpi if dpi is not None else 300
+                dpi=dpi if dpi is not None else 300,
+                color_scheme=color_scheme,
             )
             print(f"PNG generated successfully: {png_path}")
         
@@ -90,6 +93,7 @@ def main():
                 save_to=output_file,
                 scale_factor=current_scale,
                 show_grid=current_grid,
+                color_scheme=color_scheme,
             )
             print(f"LaTeX generated successfully: {tex_path}")
         
@@ -98,7 +102,8 @@ def main():
             tikz_code = draw_tree(
                 game=current_ef_file, 
                 scale_factor=current_scale, 
-                show_grid=current_grid
+                show_grid=current_grid,
+                color_scheme=color_scheme,
             )
             
             # Output the complete TikZ code
@@ -108,7 +113,7 @@ def main():
         print(f"Error: Could not find file {current_ef_file}", file=sys.stderr)
         print("Make sure the .ef file exists in the current directory", file=sys.stderr)
         sys.exit(1)
-    except RuntimeError as e:
+    except (RuntimeError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     except Exception as e:

--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -74,7 +74,32 @@ outstream: List[str] = []
 stream0: List[str] = []
 
 
-def get_player_color(player: int, color_scheme: str = "default") -> str:
+
+GAMBIT_MAX_PLAYER = 6
+MAX_COLOR_SCHEME_PLAYERS = 7  
+
+_distinctipy_n: int = MAX_COLOR_SCHEME_PLAYERS
+
+_DISTINCTIPY_FALLBACK_RGB = [
+    (117, 145, 56),   (234, 51, 35),   (0, 102, 204),  (255, 140, 0),
+    (128, 0, 128),    (0, 191, 255),   (255, 0, 255),
+]
+
+
+def _get_distinctipy_colors(n: int) -> list[tuple[int, int, int]]:
+    """Return n distinct RGB tuples (0-255). Use distinctipy if available, else fallback."""
+    try:
+        import distinctipy  
+        colors_01 = distinctipy.get_colors(n)
+        return [
+            (int(round(r * 255)), int(round(g * 255)), int(round(b * 255)))
+            for (r, g, b) in colors_01
+        ]
+    except ImportError:
+        return [_DISTINCTIPY_FALLBACK_RGB[i % len(_DISTINCTIPY_FALLBACK_RGB)] for i in range(n)]
+
+
+def get_player_color(player: int, color_scheme: Optional[str] = "default") -> str:
     """
     Get the TeX color macro name for a given player number.
 
@@ -98,21 +123,41 @@ def get_player_color(player: int, color_scheme: str = "default") -> str:
         }
 
         return color_map.get(player, "black")
+    if color_scheme == "distinctipy":
+        if 0 <= player < _distinctipy_n:
+            return f"distinct{player}"
+        return "black"
+
     return "black"
 
 
-def color_definitions() -> list[str]:
-    return [
-        "\\definecolor{chancecolorrgb}{RGB}{117,145,56}",
-        "\\definecolor{gambitredrgb}{RGB}{234,51,35}",
-        "\\newcommand\\chancecolor{chancecolorrgb}",
-        "\\newcommand\\playeronecolor{gambitredrgb}",
-        "\\newcommand\\playertwocolor{blue}",
-        "\\newcommand\\playerthreecolor{orange}",
-        "\\newcommand\\playerfourcolor{purple}",
-        "\\newcommand\\playerfivecolor{cyan}",
-        "\\newcommand\\playersixcolor{magenta}",
-    ]
+def color_definitions(color_scheme: Optional[str] = "default", n: Optional[int] = None) -> list[str]:
+   
+    global _distinctipy_n
+ 
+    if color_scheme == "gambit":
+    
+        return [
+            "\\definecolor{chancecolorrgb}{RGB}{117,145,56}",
+            "\\definecolor{gambitredrgb}{RGB}{234,51,35}",
+            "\\newcommand\\chancecolor{chancecolorrgb}",
+            "\\newcommand\\playeronecolor{gambitredrgb}",
+            "\\newcommand\\playertwocolor{blue}",
+            "\\newcommand\\playerthreecolor{orange}",
+            "\\newcommand\\playerfourcolor{purple}",
+            "\\newcommand\\playerfivecolor{cyan}",
+            "\\newcommand\\playersixcolor{magenta}",
+        ]
+    if color_scheme == "distinctipy":
+       
+        num_colors = min(n if n is not None and n > 0 else MAX_COLOR_SCHEME_PLAYERS, MAX_COLOR_SCHEME_PLAYERS)
+        _distinctipy_n = num_colors
+        colors_rgb = _get_distinctipy_colors(num_colors)
+        return [
+            f"\\definecolor{{distinct{i}}}{{RGB}}{{{r},{g},{b}}}"
+            for i, (r, g, b) in enumerate(colors_rgb)
+        ]
+    return []
 
 def outall(stream: Optional[List[str]] = None) -> None:
     """
@@ -224,6 +269,24 @@ def readfile(filename: str) -> List[str]:
         if line:
             out.append(line)
     return out
+
+
+def get_max_player_index_from_ef(ef_file: str) -> int:
+    """
+    Scan an .ef file and return the maximum player index (0 = chance, 1+ = players).
+    Used to determine how many distinct colors to generate for the distinctipy scheme.
+    """
+    lines = readfile(ef_file)
+    max_player = 0
+    for line in lines:
+        if line.startswith('%') or line.startswith('#'):
+            continue
+        parts = line.split()
+        for i, word in enumerate(parts):
+            if word == "player" and i + 1 < len(parts) and parts[i + 1].isdigit():
+                max_player = max(max_player, int(parts[i + 1]))
+                break
+    return max_player
 
 
 def fformat(x: float, places: int = 3) -> str:
@@ -1313,7 +1376,7 @@ def isetgen(words: List[str], color_scheme: str = "default") -> None:
 
 ########### command-line arguments
 
-def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], Optional[int]]:
+def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], Optional[int], str]:
     """
     Process command-line arguments to set global configuration.
     
@@ -1324,16 +1387,17 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
         argv: List of command-line arguments (including script name).
         
     Returns:
-        Tuple of (output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi) where:
+        Tuple of (output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi,color_scheme) where:
         - output_mode: 'tikz', 'pdf', 'png', or 'tex'
         - pdf_requested: True if --pdf flag was provided
         - png_requested: True if --png flag was provided
         - tex_requested: True if --tex flag was provided
         - output_file: Custom output filename if specified
         - dpi: DPI setting for PNG output (None if not specified)
+        - color_scheme: Color scheme for player nodes (default, gambit, distinctipy)
     """
     global grid
-    global scale 
+    global scale
     global ef_file
     
     pdf_requested = False
@@ -1341,6 +1405,7 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
     tex_requested = False
     output_file = None
     dpi = None
+    color_scheme = "default"
     
     for arg in argv[1:]:
         if arg[:5] == "scale":
@@ -1378,6 +1443,14 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
             except ValueError:
                 print("Warning: Invalid DPI value, using default 300", file=sys.stderr)
                 dpi = 300
+        elif arg.startswith("--color-scheme="):
+            color_scheme = arg[15:].strip().lower()
+            if color_scheme not in ("default", "gambit", "distinctipy"):
+                print(
+                    "Warning: color-scheme must be default, gambit, or distinctipy; using default",
+                    file=sys.stderr
+                )
+                color_scheme = "default"
         elif arg.endswith('.ef'):
             ef_file = arg
         else:
@@ -1394,7 +1467,7 @@ def commandline(argv: List[str]) -> tuple[str, bool, bool, bool, Optional[str], 
     else:
         output_mode = "tikz"
     
-    return (output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi)
+    return (output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme)
 
 def ef_to_tex(
     ef_file: str,
@@ -1596,7 +1669,14 @@ def generate_tikz(
         f"\\treethickn{edge_thickness}pt",
     ]
     # Step 2a: Define player color macros
-    macro_definitions.extend(color_definitions())
+    distinctipy_n = None
+    if color_scheme == "distinctipy" and isinstance(ef_file, str) and ef_file.lower().endswith(".ef"):
+        try:
+            max_player = get_max_player_index_from_ef(ef_file)
+            distinctipy_n = min(max_player + 1, MAX_COLOR_SCHEME_PLAYERS)
+        except Exception:
+            pass
+    macro_definitions.extend(color_definitions(color_scheme, n=distinctipy_n))
 
     # Step 3: Combine everything into complete TikZ code
     tikz_code = """% TikZ code with built-in styling for game trees

--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -2072,7 +2072,7 @@ def generate_png(
             # Generate PDF using existing function
             generate_pdf(
                 game=game,
-                save_to=save_to,
+                save_to=str(temp_pdf),
                 scale_factor=scale_factor,
                 level_scaling=level_scaling,
                 sublevel_scaling=sublevel_scaling,

--- a/tests/test_drawtree.py
+++ b/tests/test_drawtree.py
@@ -278,7 +278,6 @@ class TestDrawTreeFunction:
             assert "\\begin{tikzpicture}" in result
             assert "\\end{tikzpicture}" in result
             # Check for built-in macro definitions
-            assert "\\newcommand\\chancecolor" in result
             assert "\\newdimen\\ndiam" in result
             assert "\\ndiam1.5mm" in result
             assert "\\newdimen\\paydown" in result
@@ -374,9 +373,9 @@ class TestDrawTreeFunction:
 
         try:
             result = draw_tree.generate_tikz(ef_file_path)
-            # Should work with built-in macros
+            # Should work with built-in macros 
             assert "\\begin{tikzpicture}" in result
-            assert "\\newcommand\\chancecolor" in result
+            assert "\\newdimen\\ndiam" in result
         finally:
             os.unlink(ef_file_path)
 
@@ -549,86 +548,158 @@ class TestCommandlineArguments:
     def test_commandline_png_flag(self):
         """Test --png flag parsing."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--png'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert output_mode == "png"
         assert not pdf_requested
         assert png_requested
         assert not tex_requested
         assert output_file is None
         assert dpi is None
+        assert color_scheme == "default"
 
     def test_commandline_png_with_dpi(self):
         """Test --png flag with --dpi option."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--png', '--dpi=600'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert output_mode == "png"
         assert not pdf_requested
         assert png_requested
         assert not tex_requested
         assert output_file is None
         assert dpi == 600
+        assert color_scheme == "default"
 
     def test_commandline_png_output_file(self):
         """Test PNG output with custom filename."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--output=custom.png'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert output_mode == "png"
         assert not pdf_requested
         assert png_requested
         assert not tex_requested
         assert output_file == "custom.png"
         assert dpi is None
+        assert color_scheme == "default"
 
     def test_commandline_pdf_output_file(self):
         """Test PDF output with custom filename."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--output=custom.pdf'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert output_mode == "pdf"
         assert pdf_requested
         assert not png_requested
         assert not tex_requested
         assert output_file == "custom.pdf"
         assert dpi is None
+        assert color_scheme == "default"
 
     def test_commandline_tex_flag(self):
         """Test --tex flag parsing."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--tex'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert output_mode == "tex"
         assert not pdf_requested
         assert not png_requested
         assert tex_requested
         assert output_file is None
         assert dpi is None
+        assert color_scheme == "default"
 
     def test_commandline_tex_output_file(self):
         """Test LaTeX output with custom filename."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--output=custom.tex'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert output_mode == "tex"
         assert not pdf_requested
         assert not png_requested
         assert tex_requested
         assert output_file == "custom.tex"
         assert dpi is None
+        assert color_scheme == "default"
 
     def test_commandline_invalid_dpi(self):
         """Test invalid DPI values."""
         # Too low DPI should default to 300
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--png', '--dpi=50'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert dpi == 300  # Should default to 300 for out-of-range values
 
         # Too high DPI should default to 300
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--png', '--dpi=5000'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert dpi == 300  # Should default to 300 for out-of-range values
 
     def test_commandline_invalid_dpi_string(self):
         """Test non-numeric DPI values."""
         result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--png', '--dpi=high'])
-        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi = result
+        output_mode, pdf_requested, png_requested, tex_requested, output_file, dpi, color_scheme = result
         assert dpi == 300  # Should default to 300 for invalid values
+
+    def test_commandline_color_scheme(self):
+        """Test --color-scheme parsing: default when absent, gambit/distinctipy when set, default for invalid."""
+        result = draw_tree.commandline(['draw_tree.py', 'test.ef'])
+        *_, color_scheme = result
+        assert color_scheme == "default"
+        result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--color-scheme=gambit'])
+        *_, color_scheme = result
+        assert color_scheme == "gambit"
+        result = draw_tree.commandline(['draw_tree.py', 'test.ef', '--color-scheme=unknown'])
+        *_, color_scheme = result
+        assert color_scheme == "default"
+
+
+class TestColorSchemeAndMaxPlayer:
+    """Tests for color scheme and get_max_player_index_from_ef."""
+
+    def test_get_player_color(self):
+        """Default returns black; gambit returns macros (and black for player > 6); distinctipy returns distinctN or black."""
+        assert draw_tree.get_player_color(1) == "black"
+        assert draw_tree.get_player_color(0, "gambit") == "\\chancecolor"
+        assert draw_tree.get_player_color(6, "gambit") == "\\playersixcolor"
+        assert draw_tree.get_player_color(7, "gambit") == "black"
+        draw_tree.color_definitions("distinctipy", n=2)
+        try:
+            assert draw_tree.get_player_color(0, "distinctipy") == "distinct0"
+            assert draw_tree.get_player_color(2, "distinctipy") == "black"
+        finally:
+            draw_tree.color_definitions("distinctipy", n=7)
+
+    def test_color_definitions(self):
+        """Default/unknown return []; gambit has definecolor/newcommand; distinctipy has definecolor for distinct0,1,..."""
+        assert draw_tree.color_definitions() == []
+        result = draw_tree.color_definitions("gambit")
+        assert any("\\newcommand\\chancecolor" in line for line in result)
+        result = draw_tree.color_definitions("distinctipy", n=2)
+        assert len(result) == 2
+        assert any("\\definecolor{distinct0}" in line for line in result)
+
+    def test_get_max_player_index_from_ef(self):
+        """No player lines → 0; file with player 1 and 2 → 2."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.ef') as f:
+            f.write("# comment\nlevel 0 node x\n")
+            path = f.name
+        try:
+            assert draw_tree.get_max_player_index_from_ef(path) == 0
+        finally:
+            os.unlink(path)
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.ef') as f:
+            f.write("player 1 name I\nlevel 0 node 1 player 1\nlevel 2 node 2 player 2\n")
+            path = f.name
+        try:
+            assert draw_tree.get_max_player_index_from_ef(path) == 2
+        finally:
+            os.unlink(path)
+
+    def test_generate_tikz_color_schemes(self):
+        """generate_tikz with gambit includes chancecolor; with distinctipy includes definecolor distinct0."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.ef') as ef:
+            ef.write("player 1 name I\nlevel 0 node 1 player 1\n")
+            path = ef.name
+        try:
+            assert "\\newcommand\\chancecolor" in draw_tree.generate_tikz(path, color_scheme="gambit")
+            assert "\\definecolor{distinct0}" in draw_tree.generate_tikz(path, color_scheme="distinctipy")
+        finally:
+            os.unlink(path)
 
 
 def test_efg_dl_ef_conversion_examples():


### PR DESCRIPTION
---

### Summary

This PR extends the colour scheme functionality in `draw_tree` and also fixes a PNG generation bug identified during testing.

It now:

* Resolves **#14** by adding improved player-based colouring options.
* Fixes a PNG conversion issue (likely related to #37) where the CLI attempted to convert a non-existent temporary PDF file instead of using the actual generated PDF path.

This contribution is submitted as part of my GSoC 2026 application (Project Idea 3: Layout algorithm for visualising game trees).

---

###  Changes

####  Colour Scheme Improvements (Fixes #14)

* Improved existing `"gambit"` colour scheme:

  * Ensures proper scaling for multiple players.
  * Handles cases where the number of players exceeds predefined colours.

* Added new `"distinctipy"` colour scheme:

  * Uses the `distinctipy` package to dynamically generate visually distinct colours.
  * Suitable for games with many players.
  * Improves clarity in larger game trees.

* Updated `get_player_color()`:

  * Added support for multiple schemes via `color_scheme` parameter.
  * Preserved backward compatibility (default behaviour unchanged).

---

#### PNG Generation Fix (Related to #37)

* Fixed CLI PNG export logic.
* Previously, PNG conversion attempted to use a temporary PDF path that was never written.
* Updated logic to:

  * Use the actual PDF path returned by `generate_pdf()`.
  * Ensure Ghostscript / ImageMagick operate on an existing file.
* Verified successful PNG generation locally.

---

###  Dependencies

* `distinctipy`

---

###  Testing

* Tested locally using sample `.ef` files.
* Verified correct TikZ output for:

  * Default scheme
  * `"gambit"` scheme
  * `"distinctipy"` scheme
* Verified:

  * PDF generation works
  * PNG generation works (after fix)
  * No regression in existing functionality

---
Fixes #14 
---
### Default
<img width="720" height="769" alt="screenshot-2026-03-03_13-51-14" src="https://github.com/user-attachments/assets/a50d0196-c91b-4b49-96ce-41b8d9dd5ec8" />

---

### Gambit
<img width="1014" height="820" alt="screenshot-2026-03-03_13-50-56" src="https://github.com/user-attachments/assets/169647e3-65b1-4322-a452-36f6f2738a2d" />

---

### Distinctipy
<img width="904" height="784" alt="screenshot-2026-03-03_13-52-02" src="https://github.com/user-attachments/assets/cc4e6f45-c529-4c67-b66f-011159681afa" />

---

### Fixes [#37]

----
<img width="1498" height="732" alt="screenshot-2026-03-03_17-19-10" src="https://github.com/user-attachments/assets/7f5c58c1-7731-4e34-945e-369ba3e01b73" />

----

Closes #14 

---

Closes #37

---