### PR TITLE
Fix/latex deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install LaTeX and pdf2svg
       run: |
         sudo apt-get update
-        sudo apt-get install -y texlive-full pdf2svg
+        sudo apt-get install -y texlive-pictures texlive-latex-extra ghostscript pdf2svg
         
     - name: Install dependencies
       run: |

--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -1850,7 +1850,7 @@ def latex_wrapper(tikz_code: str) -> str:
         Complete LaTeX document as a string.
     """
     latex_document = f"""\\documentclass[tikz,border=10pt]{{standalone}}
-                        \\usepackage{{newpxtext,newpxmath}}
+                        \\IfFileExists{{newpxtext.sty}}{{\\usepackage{{newpxtext,newpxmath}}}}{{}}
                         \\linespread{{1.10}}
                         \\usetikzlibrary{{shapes}}
                         \\usetikzlibrary{{arrows.meta}}


### PR DESCRIPTION
Closes gambitproject/draw_tree#41.
The docs recommended a full TeX Live install (texlive-full, on the order of ~1.5 GB) for PDF/PNG/SVG. The project only needs a small slice of that stack, and the generated document was loading newpxtext / newpxmath unconditionally, which pulls in a heavy font stack on many systems.

**What changed**
latex_wrapper in core.py — newpx is now optional. The wrapper uses \IfFileExists{newpxtext.sty}{...}{} so Palatino-style fonts load when present and compilation still succeeds with default fonts when they are not.
CI (.github/workflows/test.yml) — Replaced texlive-full with texlive-pictures, texlive-latex-extra, plus ghostscript and pdf2svg so CI mirrors a lean setup and runs faster with less download.

**How to verify**
pytest tests/ (as in CI)
