### PR TITLE
fix: define colors up to max player ID for non-consecutive IDs

### DIFF
--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -1696,7 +1696,10 @@ def generate_tikz(
             shared_terminal_depth=shared_terminal_depth,
         )
 
-    # Determine the number of players for dynamic color schemes
+    # Determine the number of players for dynamic color schemes.
+    # Use max(player_ids) rather than len(player_ids) so that
+    # non-consecutive IDs (e.g. players 1, 2, 5) still get all
+    # required color definitions (p1rgb … p5rgb).
     num_players = 0
     if not isinstance(game, str):
         try:
@@ -1714,7 +1717,7 @@ def generate_tikz(
                             player_nums.add(p)
                     except (IndexError, ValueError):
                         pass
-            num_players = len(player_nums) if player_nums else 6
+            num_players = max(player_nums) if player_nums else 6
         except Exception:
             num_players = 6
 


### PR DESCRIPTION
**Problem**

For distinctipy and colorblind, LaTeX colour names are p1rgb, p2rgb, … and get_player_color() uses the actual player index (p{player}rgb). color_definitions() was driven by num_players taken as len(player_ids) for .ef games.
If a game used non-consecutive player IDs (e.g. 1, 2, 5), only three colours (p1rgb–p3rgb) were defined while the tree still referenced p5rgb, which broke LaTeX compilation with an undefined colour.

**Solution**

When inferring num_players from .ef player N lines, use max(player_nums) instead of len(player_nums), so the palette spans every ID that can appear in the diagram.
pygambit games are unchanged: num_players = len(game.players) still matches consecutive Gambit player indices.