### PR TITLE
added detection of duplicate node id

### DIFF
--- a/src/draw_tree/core.py
+++ b/src/draw_tree/core.py
@@ -1300,6 +1300,15 @@ def level(
     # effective_xs = -xs if _horizontal else xs  # REMOVED: using explicit _horizontal checks for clarity
     # direction down (for later expansion)
     yy = -lev
+    if nodeid in nodes:
+        # The TikZ output for the previous definition has already been
+        # emitted (drawtree streams as it parses), so we don't try to
+        # undo it.  Just warn -- this is almost always a copy-paste bug
+        # in the .ef file (e.g. two "level 4 node 1" lines under
+        # different parents instead of "node 1" and "node 2").
+        error("duplicate node identifier '" + nodeid +
+              "'; node identifiers must be unique within a level "
+              "(this entry overwrites the earlier one in the node table)")
     nodes[nodeid] = {"x": xx, "y": yy, "player": p}
     nodes[nodeid]["xshift"] = xs
     nodes[nodeid]["move"] = mov


### PR DESCRIPTION
This detects if a node is declared twice in the .ef file, which is usually a manual edit error but violates the tree property e.g. for the EF to EFG converter, which fails on such .ef input.
The following is a sample input file where the error occurs but the .tex output is still OK (now with an
error warning in the .tex output); the last two lines should be level 4 node 3, level 4 node 4.

player 1 name 1
player 2 name 2
player 3 name 3
level 0 node 1 player 1
level 2 node 1 player 2 xshift -a=2 from 0,1 move L
level 2 node 2 player 3 xshift a from 0,1 move R
level 4 node 1 xshift -c=1 from 2,1 move a payoffs 1 2 3
level 4 node 2 xshift c from 2,1 move b payoffs 5 0 1
level 4 node 1 xshift -c from 2,2 move S payoffs 0 2 1
level 4 node 2 xshift c from 2,2 move T payoffs 2 1 2
