### PR TITLE
Remove online GUI link

### DIFF
--- a/docs/gui.md
+++ b/docs/gui.md
@@ -2,7 +2,8 @@
 
 `gtdraw` includes a lightweight, interactive GUI built with Streamlit. It allows you to upload `.ef` or `.efg` files and adjust drawing parameters in real-time, previewing changes visually. You can run the GUI locally or used our hosted version on the Streamlit Community Cloud:
 
-:::{card} 🚀 Try GTDraw Online!
+<!-- Note: GTDraw can be deployed to the Streamlit community hub, but on a free tier will not remain live constantly -->
+<!-- :::{card} 🚀 Try GTDraw Online!
 :link: https://gtdraw.streamlit.app/
 
 **Visualize your game trees instantly.** No installation required.
@@ -12,7 +13,7 @@
 :width: 300px
 :align: center
 ```
-:::
+::: -->
 
 ## Running the GUI locally
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,8 @@ It can generate TikZ code, LaTeX documents, PDFs, PNGs, and SVGs from game speci
 
 > GTDraw was originally developed by [Bernhard von Stengel](https://www.lse.ac.uk/people/bernhard-von-stengel) at the London School of Economics. It is being developed further as part of the [Gambit project](https://www.gambit-project.org) out of The Alan Turing Institute.
 
-:::{card} 🚀 Try GTDraw Online!
+<!-- Note: GTDraw can be deployed to the Streamlit community hub, but on a free tier will not remain live constantly -->
+<!-- :::{card} 🚀 Try GTDraw Online!
 :link: https://gtdraw.streamlit.app/
 
 **Visualize your game trees instantly.** No installation required.
@@ -15,7 +16,7 @@ It can generate TikZ code, LaTeX documents, PDFs, PNGs, and SVGs from game speci
 :width: 300px
 :align: center
 ```
-:::
+::: -->
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,12 @@
 GTDraw is a game tree drawing tool for publication-ready extensive form games in Game Theory.
 It can generate TikZ code, LaTeX documents, PDFs, PNGs, and SVGs from game specifications.
 
+```{image} ../img/example.svg
+:alt: Example
+:width: 300px
+:align: center
+```
+
 > GTDraw was originally developed by [Bernhard von Stengel](https://www.lse.ac.uk/people/bernhard-von-stengel) at the London School of Economics. It is being developed further as part of the [Gambit project](https://www.gambit-project.org) out of The Alan Turing Institute.
 
 <!-- Note: GTDraw can be deployed to the Streamlit community hub, but on a free tier will not remain live constantly -->
@@ -17,7 +23,6 @@ It can generate TikZ code, LaTeX documents, PDFs, PNGs, and SVGs from game speci
 :align: center
 ```
 ::: -->
-
 
 
 ```{tableofcontents}

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -8,9 +8,9 @@ project:
     - file: installation.md
     - file: creating_games.md
     - file: ef_format.md
+    - file: gui.md
     - file: cli.md
     - file: python_api.md
-    - file: gui.md
     - title: Developer Guide
       children:
         - file: developer/development.md


### PR DESCRIPTION
Closes #106 

@wyz2368 on reflection the Streamlit community hub hosting is a bit unreliable. For now I will just remove it (since it is not deployed with the new name anyway). The option remains to redeploy it in future if another dev desires to do so.